### PR TITLE
Make monkeys tamable

### DIFF
--- a/src/main/java/com/nuggylib/naughtymonkeys/common/entity/Monkey.java
+++ b/src/main/java/com/nuggylib/naughtymonkeys/common/entity/Monkey.java
@@ -8,38 +8,473 @@ import com.nuggylib.naughtymonkeys.common.world.entity.ai.goal.TemptOnlyByBanana
 import com.nuggylib.naughtymonkeys.common.world.entity.projectile.AbstractMonkeyPoo;
 import com.nuggylib.naughtymonkeys.common.world.entity.projectile.NaughtyMonkeysProjectileUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.AgeableMob;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.MobSpawnType;
+import net.minecraft.util.TimeUtil;
+import net.minecraft.util.valueproviders.UniformInt;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ai.goal.*;
-import net.minecraft.world.entity.ai.goal.target.HurtByTargetGoal;
-import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
+import net.minecraft.world.entity.ai.goal.target.*;
 import net.minecraft.world.entity.animal.Animal;
+import net.minecraft.world.entity.animal.Cat;
+import net.minecraft.world.entity.animal.Turtle;
+import net.minecraft.world.entity.animal.Wolf;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.entity.animal.horse.Llama;
+import net.minecraft.world.entity.monster.AbstractSkeleton;
+import net.minecraft.world.entity.monster.Creeper;
+import net.minecraft.world.entity.monster.Ghast;
 import net.minecraft.world.entity.monster.RangedAttackMob;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import net.minecraft.world.item.*;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.Random;
+import java.util.UUID;
+import java.util.function.Predicate;
 
 /**
  * {@link net.minecraft.world.entity.monster.Skeleton} {@link net.minecraft.world.level.block.Blocks}
  */
-public class Monkey extends Animal implements RangedAttackMob {
+public class Monkey extends TamableAnimal implements RangedAttackMob, NeutralMob {
+    private static final EntityDataAccessor<Boolean> DATA_INTERESTED_ID = SynchedEntityData.defineId(Monkey.class, EntityDataSerializers.BOOLEAN);
+    private static final EntityDataAccessor<Integer> DATA_COLLAR_COLOR = SynchedEntityData.defineId(Monkey.class, EntityDataSerializers.INT);
+    private static final EntityDataAccessor<Integer> DATA_REMAINING_ANGER_TIME = SynchedEntityData.defineId(Monkey.class, EntityDataSerializers.INT);
+    public static final Predicate<LivingEntity> PREY_SELECTOR = (p_30437_) -> {
+        EntityType<?> entitytype = p_30437_.getType();
+        return entitytype == EntityType.SHEEP || entitytype == EntityType.RABBIT || entitytype == EntityType.FOX;
+    };
     private int eatAnimationTick;
-    public Monkey(EntityType<? extends Animal> type, Level world) {
+    private static final float START_HEALTH = 8.0F;
+    private static final float TAME_HEALTH = 20.0F;
+    private float interestedAngle;
+    private float interestedAngleO;
+    private boolean isWet;
+    private boolean isShaking;
+    private float shakeAnim;
+    private float shakeAnimO;
+
+    private static final UniformInt PERSISTENT_ANGER_TIME = TimeUtil.rangeOfSeconds(20, 39);
+
+    @javax.annotation.Nullable
+    private UUID persistentAngerTarget;
+    public Monkey(EntityType<? extends Monkey> type, Level world) {
         super(type, world);
+        this.setTame(false);
+    }
+    @Override
+    protected void registerGoals() {
+
+        RangedMonkeyPooAttackGoal<Monkey> monkeyPooRangedAttackGoal = new RangedMonkeyPooAttackGoal<>(this, 1.0D, 50, 15.0F);
+
+        this.goalSelector.addGoal(0, new FloatGoal(this));
+        this.goalSelector.addGoal(2, new SitWhenOrderedToGoal(this));
+        this.goalSelector.addGoal(6, new FollowOwnerGoal(this, 1.0D, 10.0F, 2.0F, false));
+        this.goalSelector.addGoal(2, new BreedGoal(this, 1.0D));
+        this.goalSelector.addGoal(8, new WaterAvoidingRandomStrollGoal(this, 1.0D));
+//        this.goalSelector.addGoal(9, new BegGoal(this, 8.0F));
+        this.goalSelector.addGoal(3, new TemptOnlyByBananaHatWearersGoal<>(this, 1.25D, Ingredient.of(NaughtyMonkeysItems.BANANA.get()), false));
+        this.goalSelector.addGoal(4, new FollowParentGoal(this, 1.25D));
+        this.goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D));
+        this.goalSelector.addGoal(6, new LookAtPlayerGoal(this, Player.class, 8.0F));
+        this.goalSelector.addGoal(7, new RandomLookAroundGoal(this));
+        this.goalSelector.addGoal(4, monkeyPooRangedAttackGoal);
+
+        this.targetSelector.addGoal(0, new OwnerHurtByTargetGoal(this));
+        this.targetSelector.addGoal(3, new HurtByTargetGoal(this));
+        this.targetSelector.addGoal(4, new NearestAttackableTargetGoal<>(this, Player.class, 10, true, false, this::isAngryAt));
+        this.targetSelector.addGoal(5, new NonTameRandomTargetGoal<>(this, Animal.class, false, PREY_SELECTOR));
+//        this.targetSelector.addGoal(6, new NonTameRandomTargetGoal<>(this, Turtle.class, false, Turtle.BABY_ON_LAND_SELECTOR));
+        this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, true));
+        this.targetSelector.addGoal(7, new NearestAttackableTargetGoal<>(this, AbstractSkeleton.class, false));
+        this.targetSelector.addGoal(8, new ResetUniversalAngerTargetGoal<>(this, true));
+
+    }
+    @NotNull
+    public static AttributeSupplier.Builder registerAttributes() {
+        return Monkey.createMobAttributes()
+                .add(Attributes.MAX_HEALTH, 10.0)
+                .add(Attributes.MOVEMENT_SPEED, 0.2)
+                .add(Attributes.ATTACK_DAMAGE, 2.0D);
     }
 
+    protected void defineSynchedData() {
+        super.defineSynchedData();
+        this.entityData.define(DATA_INTERESTED_ID, false);
+        this.entityData.define(DATA_COLLAR_COLOR, DyeColor.BLUE.getId());
+        this.entityData.define(DATA_REMAINING_ANGER_TIME, 0);
+    }
+
+    protected void playStepSound(BlockPos p_30415_, BlockState p_30416_) {
+        this.playSound(SoundEvents.WOLF_STEP, 0.15F, 1.0F);
+    }
+
+    public void addAdditionalSaveData(CompoundTag p_30418_) {
+        super.addAdditionalSaveData(p_30418_);
+        p_30418_.putByte("CollarColor", (byte)this.getCollarColor().getId());
+        this.addPersistentAngerSaveData(p_30418_);
+    }
+
+    public void readAdditionalSaveData(CompoundTag p_30402_) {
+        super.readAdditionalSaveData(p_30402_);
+        if (p_30402_.contains("CollarColor", 99)) {
+            this.setCollarColor(DyeColor.byId(p_30402_.getInt("CollarColor")));
+        }
+
+        this.readPersistentAngerSaveData(this.level, p_30402_);
+    }
+    // TODO: Replace with monkey sound
+    protected SoundEvent getAmbientSound() {
+        if (this.isAngry()) {
+            return SoundEvents.WOLF_GROWL;
+        } else if (this.random.nextInt(3) == 0) {
+            return this.isTame() && this.getHealth() < 10.0F ? SoundEvents.WOLF_WHINE : SoundEvents.WOLF_PANT;
+        } else {
+            return SoundEvents.WOLF_AMBIENT;
+        }
+    }
+    // TODO: Replace with monkey sound
+    protected SoundEvent getHurtSound(DamageSource p_30424_) {
+        return SoundEvents.WOLF_HURT;
+    }
+    // TODO: Replace with monkey sound
+    protected SoundEvent getDeathSound() {
+        return SoundEvents.WOLF_DEATH;
+    }
+    protected float getSoundVolume() {
+        return 0.4F;
+    }
+    @Override
+    public void aiStep() {
+        this.updateSwingTime();
+        this.updateNoActionTime();
+        super.aiStep();
+
+        if (!this.level.isClientSide && this.isWet && !this.isShaking && !this.isPathFinding() && this.onGround) {
+            this.isShaking = true;
+            this.shakeAnim = 0.0F;
+            this.shakeAnimO = 0.0F;
+            this.level.broadcastEntityEvent(this, (byte)8);
+        }
+
+        if (!this.level.isClientSide) {
+            this.updatePersistentAnger((ServerLevel)this.level, true);
+        }
+    }
+
+    public void tick() {
+        super.tick();
+        if (this.isAlive()) {
+            this.interestedAngleO = this.interestedAngle;
+            if (this.isInterested()) {
+                this.interestedAngle += (1.0F - this.interestedAngle) * 0.4F;
+            } else {
+                this.interestedAngle += (0.0F - this.interestedAngle) * 0.4F;
+            }
+
+            if (this.isInWaterRainOrBubble()) {
+                this.isWet = true;
+                if (this.isShaking && !this.level.isClientSide) {
+                    this.level.broadcastEntityEvent(this, (byte)56);
+                    this.cancelShake();
+                }
+            } else if ((this.isWet || this.isShaking) && this.isShaking) {
+                if (this.shakeAnim == 0.0F) {
+                    this.playSound(SoundEvents.WOLF_SHAKE, this.getSoundVolume(), (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F);
+                    this.gameEvent(GameEvent.WOLF_SHAKING);
+                }
+
+                this.shakeAnimO = this.shakeAnim;
+                this.shakeAnim += 0.05F;
+                if (this.shakeAnimO >= 2.0F) {
+                    this.isWet = false;
+                    this.isShaking = false;
+                    this.shakeAnimO = 0.0F;
+                    this.shakeAnim = 0.0F;
+                }
+
+                if (this.shakeAnim > 0.4F) {
+                    float f = (float)this.getY();
+                    int i = (int)(Mth.sin((this.shakeAnim - 0.4F) * (float)Math.PI) * 7.0F);
+                    Vec3 vec3 = this.getDeltaMovement();
+
+                    for(int j = 0; j < i; ++j) {
+                        float f1 = (this.random.nextFloat() * 2.0F - 1.0F) * this.getBbWidth() * 0.5F;
+                        float f2 = (this.random.nextFloat() * 2.0F - 1.0F) * this.getBbWidth() * 0.5F;
+                        this.level.addParticle(ParticleTypes.SPLASH, this.getX() + (double)f1, (double)(f + 0.8F), this.getZ() + (double)f2, vec3.x, vec3.y, vec3.z);
+                    }
+                }
+            }
+
+        }
+    }
+    private void cancelShake() {
+        this.isShaking = false;
+        this.shakeAnim = 0.0F;
+        this.shakeAnimO = 0.0F;
+    }
+    public void die(DamageSource p_30384_) {
+        this.isWet = false;
+        this.isShaking = false;
+        this.shakeAnimO = 0.0F;
+        this.shakeAnim = 0.0F;
+        super.die(p_30384_);
+    }
+    public boolean isWet() {
+        return this.isWet;
+    }
+    public float getWetShade(float p_30447_) {
+        return Math.min(0.5F + Mth.lerp(p_30447_, this.shakeAnimO, this.shakeAnim) / 2.0F * 0.5F, 1.0F);
+    }
+    public float getBodyRollAngle(float p_30433_, float p_30434_) {
+        float f = (Mth.lerp(p_30433_, this.shakeAnimO, this.shakeAnim) + p_30434_) / 1.8F;
+        if (f < 0.0F) {
+            f = 0.0F;
+        } else if (f > 1.0F) {
+            f = 1.0F;
+        }
+
+        return Mth.sin(f * (float)Math.PI) * Mth.sin(f * (float)Math.PI * 11.0F) * 0.15F * (float)Math.PI;
+    }
+    public float getHeadRollAngle(float p_30449_) {
+        return Mth.lerp(p_30449_, this.interestedAngleO, this.interestedAngle) * 0.15F * (float)Math.PI;
+    }
+    protected float getStandingEyeHeight(Pose p_30409_, EntityDimensions p_30410_) {
+        return p_30410_.height * 0.8F;
+    }
+    public int getMaxHeadXRot() {
+        return this.isInSittingPose() ? 20 : super.getMaxHeadXRot();
+    }
+    public boolean hurt(DamageSource p_30386_, float p_30387_) {
+        if (this.isInvulnerableTo(p_30386_)) {
+            return false;
+        } else {
+            Entity entity = p_30386_.getEntity();
+            this.setOrderedToSit(false);
+            if (entity != null && !(entity instanceof Player) && !(entity instanceof AbstractArrow)) {
+                p_30387_ = (p_30387_ + 1.0F) / 2.0F;
+            }
+
+            return super.hurt(p_30386_, p_30387_);
+        }
+    }
+    public boolean doHurtTarget(Entity p_30372_) {
+        boolean flag = p_30372_.hurt(DamageSource.mobAttack(this), (float)((int)this.getAttributeValue(Attributes.ATTACK_DAMAGE)));
+        if (flag) {
+            this.doEnchantDamageEffects(this, p_30372_);
+        }
+
+        return flag;
+    }
+    @NotNull
+    public void setTame(boolean p_30443_) {
+        super.setTame(p_30443_);
+        if (p_30443_) {
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(20.0D);
+            this.setHealth(20.0F);
+        } else {
+            this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(8.0D);
+        }
+
+        this.getAttribute(Attributes.ATTACK_DAMAGE).setBaseValue(4.0D);
+    }
+    @Override
+    public InteractionResult mobInteract(Player player, InteractionHand hand) {
+        super.mobInteract(player, hand);
+
+        ItemStack itemstack = player.getItemInHand(hand);
+        Item item = itemstack.getItem();
+        if (this.level.isClientSide) {
+            boolean flag = this.isOwnedBy(player) || this.isTame() || itemstack.is(Items.BONE) && !this.isTame() && !this.isAngry();
+            return flag ? InteractionResult.CONSUME : InteractionResult.PASS;
+        } else {
+            if (this.isTame()) {
+                if (this.isFood(itemstack) && this.getHealth() < this.getMaxHealth()) {
+                    if (!player.getAbilities().instabuild) {
+                        itemstack.shrink(1);
+                    }
+
+                    this.heal((float)item.getFoodProperties().getNutrition());
+                    this.gameEvent(GameEvent.MOB_INTERACT, this.eyeBlockPosition());
+                    return InteractionResult.SUCCESS;
+                }
+
+                if (!(item instanceof DyeItem)) {
+                    InteractionResult interactionresult = super.mobInteract(player, hand);
+                    if ((!interactionresult.consumesAction() || this.isBaby()) && this.isOwnedBy(player)) {
+                        this.setOrderedToSit(!this.isOrderedToSit());
+                        this.jumping = false;
+                        this.navigation.stop();
+                        this.setTarget((LivingEntity)null);
+                        return InteractionResult.SUCCESS;
+                    }
+
+                    return interactionresult;
+                }
+
+                DyeColor dyecolor = ((DyeItem)item).getDyeColor();
+                if (dyecolor != this.getCollarColor()) {
+                    this.setCollarColor(dyecolor);
+                    if (!player.getAbilities().instabuild) {
+                        itemstack.shrink(1);
+                    }
+
+                    return InteractionResult.SUCCESS;
+                }
+            } else if (itemstack.is(NaughtyMonkeysItems.BANANA_BUNCH.get())) {
+                if (!player.getAbilities().instabuild) {
+                    itemstack.shrink(1);
+                }
+
+                if (this.random.nextInt(3) == 0 && !net.minecraftforge.event.ForgeEventFactory.onAnimalTame(this, player)) {
+                    this.tame(player);
+                    this.navigation.stop();
+                    this.setTarget((LivingEntity)null);
+                    this.setOrderedToSit(true);
+                    this.level.broadcastEntityEvent(this, (byte)7);
+                } else {
+                    this.level.broadcastEntityEvent(this, (byte)6);
+                }
+
+                return InteractionResult.SUCCESS;
+            }
+
+            return super.mobInteract(player, hand);
+        }
+
+//        return super.mobInteract(player, hand);
+    }
+    public void handleEntityEvent(byte p_30379_) {
+        if (p_30379_ == 8) {
+            this.isShaking = true;
+            this.shakeAnim = 0.0F;
+            this.shakeAnimO = 0.0F;
+        } else if (p_30379_ == 56) {
+            this.cancelShake();
+        } else {
+            super.handleEntityEvent(p_30379_);
+        }
+
+    }
+    // TODO: Make tail controllable
+    public float getTailAngle() {
+        if (this.isAngry()) {
+            return 1.5393804F;
+        } else {
+            return this.isTame() ? (0.55F - (this.getMaxHealth() - this.getHealth()) * 0.02F) * (float)Math.PI : ((float)Math.PI / 5F);
+        }
+    }
+    // TODO: Add other food items (e.g., BANANA_BUNCH)
+    @Override
+    public boolean isFood(ItemStack itemStack) {
+        return itemStack.is(NaughtyMonkeysItems.BANANA.get()) || itemStack.is(NaughtyMonkeysItems.BANANA_BUNCH.get());
+    }
+    public int getMaxSpawnClusterSize() {
+        return 20;
+    }
+    @Override
+    public int getRemainingPersistentAngerTime() {
+        return this.entityData.get(DATA_REMAINING_ANGER_TIME);
+    }
+    @Override
+    public void setRemainingPersistentAngerTime(int p_30404_) {
+        this.entityData.set(DATA_REMAINING_ANGER_TIME, p_30404_);
+    }
+    @Override
+    public void startPersistentAngerTimer() {
+        this.setRemainingPersistentAngerTime(PERSISTENT_ANGER_TIME.sample(this.random));
+    }
+    @javax.annotation.Nullable
+    public UUID getPersistentAngerTarget() {
+        return this.persistentAngerTarget;
+    }
+    public DyeColor getCollarColor() {
+        return DyeColor.byId(this.entityData.get(DATA_COLLAR_COLOR));
+    }
+    public void setCollarColor(DyeColor p_30398_) {
+        this.entityData.set(DATA_COLLAR_COLOR, p_30398_.getId());
+    }
+    @Nullable
+    @Override
+    public Monkey getBreedOffspring(ServerLevel level, AgeableMob mate) {
+        Monkey monkey = NaughtyMonkeysEntities.MONKEY.get().create(level);
+        UUID uuid = this.getOwnerUUID();
+        if (uuid != null) {
+            monkey.setOwnerUUID(uuid);
+            monkey.setTame(true);
+        }
+
+        return monkey;
+    }
+    public void setIsInterested(boolean p_30445_) {
+        this.entityData.set(DATA_INTERESTED_ID, p_30445_);
+    }
+
+    // TODO: See if we want to restrict breeding to certain conditions
+//    public boolean canMate(Animal animal) {
+//        if (animal == this) {
+//            return false;
+//        } else if (!this.isTame()) {
+//            return false;
+//        } else if (!(animal instanceof Monkey)) {
+//            return false;
+//        } else {
+//            Monkey monkey = (Monkey)animal;
+//            if (!monkey.isTame()) {
+//                return false;
+//            } else if (monkey.isInSittingPose()) {
+//                return false;
+//            } else {
+//                return this.isInLove() && monkey.isInLove();
+//            }
+//        }
+//    }
+    public boolean isInterested() {
+        return this.entityData.get(DATA_INTERESTED_ID);
+    }
+    public boolean wantsToAttack(LivingEntity p_30389_, LivingEntity p_30390_) {
+        if (!(p_30389_ instanceof Creeper) && !(p_30389_ instanceof Ghast)) {
+            if (p_30389_ instanceof Monkey) {
+                Monkey monkey = (Monkey)p_30389_;
+                return !monkey.isTame() || monkey.getOwner() != p_30390_;
+            } else if (p_30389_ instanceof Player && p_30390_ instanceof Player && !((Player)p_30390_).canHarmPlayer((Player)p_30389_)) {
+                return false;
+            } else if (p_30389_ instanceof AbstractHorse && ((AbstractHorse)p_30389_).isTamed()) {
+                return false;
+            } else {
+                return !(p_30389_ instanceof TamableAnimal) || !((TamableAnimal)p_30389_).isTame();
+            }
+        } else {
+            return false;
+        }
+    }
+    public boolean canBeLeashed(Player p_30396_) {
+        return !this.isAngry() && super.canBeLeashed(p_30396_);
+    }
+    public @NotNull Vec3 getLeashOffset() {
+        return new Vec3(0.0D, (double)(0.6F * this.getEyeHeight()), (double)(this.getBbWidth() * 0.4F));
+    }
     protected void updateNoActionTime() {
         float f = this.getBrightness();
         if (f > 0.5F) {
@@ -47,48 +482,6 @@ public class Monkey extends Animal implements RangedAttackMob {
         }
 
     }
-
-    @Override
-    public void aiStep() {
-        this.updateSwingTime();
-        this.updateNoActionTime();
-        super.aiStep();
-    }
-
-    @Override
-    protected void registerGoals() {
-
-        RangedMonkeyPooAttackGoal<Monkey> monkeyPooRangedAttackGoal = new RangedMonkeyPooAttackGoal<>(this, 1.0D, 50, 15.0F);
-
-        // monkey floats
-        goalSelector.addGoal(0, new FloatGoal(this));
-        // monkey breeds
-        goalSelector.addGoal(2, new BreedGoal(this, 1.0D));
-        // monkey tempted by bananas
-        goalSelector.addGoal(3, new TemptOnlyByBananaHatWearersGoal<>(this, 1.25D, Ingredient.of(NaughtyMonkeysItems.BANANA.get()), false));
-        // babies follow parent monkeys
-        goalSelector.addGoal(4, new FollowParentGoal(this, 1.25D));
-        // monkey avoid water
-        goalSelector.addGoal(5, new WaterAvoidingRandomStrollGoal(this, 1.0D));
-        // monkey looks at players
-        goalSelector.addGoal(6, new LookAtPlayerGoal(this, Player.class, 6.0F));
-        // monkey randomly looks around
-        goalSelector.addGoal(7, new RandomLookAroundGoal(this));
-        // monkey throws poop
-        goalSelector.addGoal(4, monkeyPooRangedAttackGoal);
-        // monkey alerts others when hurt by a target entity
-        targetSelector.addGoal(1, new HurtByTargetGoal(this));
-        // monkey targets players
-        targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, Player.class, true));
-
-    }
-
-    public static AttributeSupplier.Builder registerAttributes() {
-        return Monkey.createMobAttributes()
-                .add(Attributes.MAX_HEALTH, 10.0)
-                .add(Attributes.MOVEMENT_SPEED, 0.2);
-    }
-
     public float getHeadEatAngleScale(float p_29883_) {
         if (this.eatAnimationTick > 4 && this.eatAnimationTick <= 36) {
             float f = ((float)(this.eatAnimationTick - 4) - p_29883_) / 32.0F;
@@ -97,22 +490,9 @@ public class Monkey extends Animal implements RangedAttackMob {
             return this.eatAnimationTick > 0 ? ((float)Math.PI / 5F) : this.getXRot() * ((float)Math.PI / 180F);
         }
     }
-
     protected AbstractMonkeyPoo getMonkeyPoo(ItemStack p_32156_, float p_32157_) {
         return NaughtyMonkeysProjectileUtil.getMobThrownPoop(this, p_32156_, p_32157_);
     }
-
-    @Override
-    public boolean isFood(ItemStack itemStack) {
-        return itemStack.is(NaughtyMonkeysItems.BANANA.get());
-    }
-
-    @Nullable
-    @Override
-    public AgeableMob getBreedOffspring(ServerLevel level, AgeableMob mate) {
-        return NaughtyMonkeysEntities.MONKEY.get().create(level);
-    }
-
     @Override
     public void performRangedAttack(LivingEntity monkey, float p_32142_) {
         ItemStack itemstack = new ItemStack(NaughtyMonkeysItems.MONKEY_POO.get());
@@ -125,10 +505,45 @@ public class Monkey extends Animal implements RangedAttackMob {
         this.playSound(SoundEvents.SNOWBALL_THROW, 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));
         this.level.addFreshEntity(abstractMonkeyPoo);
     }
-
     public static boolean checkSpawnRules(EntityType<? extends Animal> p_27578_, LevelAccessor levelAccessor, MobSpawnType p_27580_, BlockPos blockPos, Random p_27582_) {
         return (levelAccessor.getBlockState(blockPos.below()).is(NaughtyMonkeysTags.MONKEYS_SPAWNABLE_ON) ||
                 levelAccessor.getBlockState(blockPos.above()).is(NaughtyMonkeysTags.MONKEYS_SPAWNABLE_ON)) &&
                 isBrightEnoughToSpawn(levelAccessor, blockPos);
     }
+    @Override
+    public void setPersistentAngerTarget(@Nullable UUID p_21672_) {
+
+    }
+
+    class MonkeyAvoidEntityGoal<T extends LivingEntity> extends AvoidEntityGoal<T> {
+        private final Monkey monkey;
+
+        public MonkeyAvoidEntityGoal(Monkey p_30454_, Class<T> p_30455_, float p_30456_, double p_30457_, double p_30458_) {
+            super(p_30454_, p_30455_, p_30456_, p_30457_, p_30458_);
+            this.monkey = p_30454_;
+        }
+
+        public boolean canUse() {
+            if (super.canUse() && this.toAvoid != null) {
+                return !this.monkey.isTame() && this.avoidCat((Cat)this.toAvoid);
+            } else {
+                return false;
+            }
+        }
+
+        private boolean avoidCat(Cat p_30461_) {
+            return true;
+        }
+
+        public void start() {
+            Monkey.this.setTarget((LivingEntity)null);
+            super.start();
+        }
+
+        public void tick() {
+            Monkey.this.setTarget((LivingEntity)null);
+            super.tick();
+        }
+    }
+
 }


### PR DESCRIPTION
Make monkeys tamable (tameable) and add related functionality.

What this PR adds:
- Players can tame monkeys with banana bunches. There's a change of taming each time you feed a monkey a banana bunch, similar to how you tame wolves with bones.
- Monkeys look at random things they're interested in by turning their heads.
- Monkeys attack random targets if they're not tame.
- Monkeys attack targets that hurt their owner if they're tame.
- Baby monkeys are tame if the parents are tame.
- Players can use leads on monkeys.
- Monkeys follow their owner and obey sit commands.
- Monkeys have ambient sounds, stepping sounds, hurt sounds, and angry sounds (although, they're all wolf sounds).
- Monkeys have collars when tame (but no model or texture for collars).
- Monkeys have a darker color when wet (until they shake). 

What this PR does NOT add (TODO):
- Monkeys will still attack their owner, even if they're tame (unless their owner is wearing a banana hat). Fixed in https://github.com/nuggylib/naughty-monkeys/pull/39.
- Monkeys don't have unique sounds. They use the wolf sounds. See https://github.com/nuggylib/naughty-monkeys/pull/38
- Monkeys don't have animation support for:
    - Shaking when wet
    - Sitting
- Monkeys do not have model or texture support for tame collars. See https://github.com/nuggylib/naughty-monkeys/pull/39
- Monkey tail is not controllable or animated.
- Monkey has no breeding restrictions (e.g., must be tame, must be "in love," etc.).
- You can't tell when a monkey is wet because they're black. Fixed in https://github.com/nuggylib/naughty-monkeys/pull/39.
- Monkeys don't have custom untame target selection. Untame attack logic mimics wolf behavior.